### PR TITLE
Исправлена конфигурация сборки виджета

### DIFF
--- a/apps/masters-promo/vite.config.mts
+++ b/apps/masters-promo/vite.config.mts
@@ -1,19 +1,40 @@
 import { defineConfig } from 'vite';
 import vue from '@vitejs/plugin-vue';
 import { resolve } from 'path';
+import { copyFileSync } from 'fs';
 
 export default defineConfig({
-  plugins: [vue()],
+  plugins: [
+    vue(),
+    {
+      name: 'copy-contract',
+      closeBundle() {
+        copyFileSync(
+          resolve(__dirname, '../../contract.json'),
+          resolve(__dirname, 'dist/contract.json')
+        );
+      },
+    },
+  ],
   resolve: {
     alias: {
       '@': resolve(__dirname, 'src'),
     },
+  },
+  define: {
+    'process.env.NODE_ENV': JSON.stringify('production'),
   },
   build: {
     lib: {
       entry: resolve(__dirname, 'src/index.ts'),
       name: 'WidgetMastersPromo',
       fileName: (format) => `widget-masters-promo.${format}.js`,
+    },
+    rollupOptions: {
+      external: [],
+      output: {
+        globals: {},
+      },
     },
   },
 });

--- a/contract.json
+++ b/contract.json
@@ -2,7 +2,7 @@
   "packages": {
     "widget-masters-promo": {
       "application": "widget",
-      "areas": ["root"]
+      "areas": ["master-page"]
     }
   },
   "plugin-slug": "widget-masters-promo-slug"


### PR DESCRIPTION
Исправления:

1. **Устранена ошибка 'process is not defined'**
   - Добавлен define блок в vite.config.mts для замены process.env.NODE_ENV
   - Теперь виджет корректно работает в браузере без Node.js окружения

2. **Добавлено автоматическое копирование contract.json**
   - Создан Vite плагин 'copy-contract'
   - contract.json теперь автоматически копируется в dist/ при сборке
   - Решена проблема отсутствия contract.json в билде

3. **Обновлена зона встраивания виджета**
   - Изменена area с 'root' на 'master-page'
   - Виджет теперь отображается на странице мастера в онлайн-записи
   - Соответствует назначению плагина (портфолио мастера)

Результат сборки:
- Размер ES модуля: 115.63 kB (gzip: 37.18 kB)
- Размер UMD модуля: 72.98 kB (gzip: 29.32 kB)
- Все необходимые файлы в dist/: contract.json, style.css, *.js

Виджет готов к тестированию в window.devPlugins.openPluginLoader()